### PR TITLE
6.2.0 - Bug fixes, custom logger support, and option to specify api_version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-Gemfile.lock
-.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 ## Bug Fixes:
 * Fixed a bug in `src/api/util/converter.rb` causing noisy errors in log i.e. `<internal:pack>:8: warning: unknown pack directive '"' in '"C*"'`
 * Removed the `mysql2` dependency from the gemspec as the mysql token store is optional
-* Removed the unspecified Webrick dependency which is required only if using the built in default file system logger
-  (see Custom Logger Support enhancement)
+* Removed the unspecified `webrick` gem dependency which was only used for logging. Switched the `SDKLog::Log` class to use
+  a standard Ruby `Logger` instead under the hood as the default logger. The default logging behavior and interface is unchanged.
 
 ## Enhancements:
-* Custom Logger Support - Pass in a custom logger to `ZOHOCRMSDK::Initializer.initialize` - this supports passing in `Rails.logger`, for instance
+* Custom Logger Support - Pass in a custom logger to `ZOHOCRMSDK::Initializer.initialize` - this now supports passing in `Rails.logger`, for instance
 * Added `api_version` option to `ZOHOCRMSDK::Initializer.initialize` which defaults to `2`. This sets the crm API base path for operations from `/crm/v2/` to `/crm/v{version}/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 6.2.0
+## Bug Fixes:
+* Fixed a bug in `src/api/util/converter.rb` causing noisy errors in log i.e. `<internal:pack>:8: warning: unknown pack directive '"' in '"C*"'`
+* Removed the `mysql2` dependency from the gemspec as the mysql token store is optional
+* Removed the unspecified Webrick dependency which is required only if using the built in default file system logger
+  (see Custom Logger Support enhancement)
+
+## Enhancements:
+* Custom Logger Support - Pass in a custom logger to `ZOHOCRMSDK::Initializer.initialize` - this supports passing in `Rails.logger`, for instance
+* Added `api_version` option to `ZOHOCRMSDK::Initializer.initialize` which defaults to `2`. This sets the crm API base path for operations from `/crm/v2/` to `/crm/v{version}/`

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ZOHOCRMSDK2_0.gemspec
 gemspec
 
-gem 'mysql2'
+gem 'mysql2', '~> 0.5.2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ZOHOCRMSDK2_0.gemspec
 gemspec
+
+gem 'mysql2'
+gem 'webrick'

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'mysql2'
-gem 'webrick'

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ class Initialize
         
         log = ZOHOCRMSDK::SDKLog::Log.initialize(level:Levels::INFO, path:"/Users/user_name/Documents/rubysdk_log.log")
 
+        # or if using your own Logger such as Rails.logger
+        # log = Rails.logger
+        
         #Create an UserSignature instance that takes user Email as parameter
         user_signature = ZOHOCRMSDK::UserSignature.new('abc@zohocorp.com')
 

--- a/README.md
+++ b/README.md
@@ -203,13 +203,14 @@ require 'ZOHOCRMSDK2_0'
 
 Before you get started with creating your Ruby application, you need to register your client and authenticate the app with Zoho.
 
-| Mandatory Keys    | Optional Keys |
-| :---------------- | :------------ |
-| user              | logger        |
-| environment       | store         |
-| token             | sdk_config    |
-|                   | proxy         |
-|                   | resource_path |
+| Mandatory Keys    | Optional Keys               |
+| :---------------- |:----------------------------|
+| user              | logger                      |
+| environment       | store                       |
+| token             | sdk_config                  |
+|                   | proxy                       |
+|                   | resource_path               |
+|                   | api_version (defaults to 2) |
 ----
 
 - Create an instance of **[UserSignature](resources/UserSignature.md#usersignature)** that identifies the current user.
@@ -248,9 +249,13 @@ Before you get started with creating your Ruby application, you need to register
     ```
 
 - Create an instance of **[SDKLog::Log](resources/logger/Logger.md#logger)** Class to log exception and API information. By default, the SDK constructs a Logger instance with level - INFO and file_path - (sdk_logs.log, created in the current working directory)
+  * Or pass in a custom Logger such as `Rails.logger` or any Ruby `Logger` instance
 
     ```ruby
+    # log = Rails.logger
+    
     #
+        # OR
         # Create an instance of SDKLog::Log Class that takes two parameters
         # 1 -> Level of the log messages to be logged. Can be configured by typing Levels "::" and choose any level from the list displayed.
         # 2 -> Absolute file path, where messages need to be logged.
@@ -316,6 +321,12 @@ Before you get started with creating your Ruby application, you need to register
 
     ```ruby
     request_proxy = ZOHOCRMSDK::RequestProxy.new(host:"proxyHost", post:"proxyPort", user_name:"proxyUser", password:"password")
+    ```
+
+- Set the `api_version` if desired, for the Zoho CRM REST API. `2` is default. See [Zoho CRM APIs](https://www.zoho.com/crm/developer/docs/api)
+
+    ```ruby
+    api_version = 2
     ```
 
 ## Initializing the Application
@@ -400,6 +411,9 @@ class Initialize
         
         request_proxy = ZOHOCRMSDK::RequestProxy.new(host:"proxyHost", post:"proxyPort", user_name:"proxyUser", password:"password")
 
+        # Set the api_version if desired, for the Zoho CRM REST API. 2 is default.
+        
+        api_version = 2
         
         # The initialize method of Initializer class that takes the following arguments
         # 1 -> UserSignature instance
@@ -413,7 +427,7 @@ class Initialize
 
         #The following is the initialize method
 
-        ZOHOCRMSDK::Initializer.initialize(user: user_signature, environment: environment, token: token, store: tokenstore, sdk_config: sdk_config, resources_path: resource_path,log:log,request_proxy: request_proxy)
+        ZOHOCRMSDK::Initializer.initialize(user: user_signature, environment: environment, token: token, store: tokenstore, sdk_config: sdk_config, resources_path: resource_path,log:log,request_proxy: request_proxy, api_version: api_version)
     end
 end
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ class Initialize
         #1 -> Level of the log messages to be logged. Can be configured by typing Levels "::" and choose any level from the list displayed.
         # 2 -> Absolute file path, where messages need to be logged.
         
-        log = ZOHOCRMSDK::SDKLog::Log.initialize(level:Levels::INFO, path:"/Users/user_name/Documents/rubysdk_log.log")
+        log = ZOHOCRMSDK::SDKLog::Log.initialize(level:ZOHOCRMSDK::Levels::INFO, path:"/Users/user_name/Documents/rubysdk_log.log")
 
         # or if using your own Logger such as Rails.logger
         # log = Rails.logger

--- a/ZOHOCRMSDK2_0.gemspec
+++ b/ZOHOCRMSDK2_0.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'multipart-post', '~> 2.0'
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
   spec.add_runtime_dependency 'uri', '~> 0.10'
-  spec.add_runtime_dependency 'mysql2', '~> 0.5.2'
 end

--- a/src/com/zoho/api/authenticator/store/db_store.rb
+++ b/src/com/zoho/api/authenticator/store/db_store.rb
@@ -16,7 +16,7 @@ module ZOHOCRMSDK
       # @param password A String containing the DataBase password.
       # @param port_number A String containing the DataBase port number.
       def initialize(host: Constants::MYSQL_HOST, database_name: Constants::MYSQL_DATABASE_NAME ,table_name: Constants::MYSQL_TABLE_NAME,user_name: Constants::MYSQL_USER_NAME,password: '',port_number: Constants::MYSQL_PORT_NUMBER )
-        require 'mysql2' unless const_defined?(:Mysql2)
+        require 'mysql2' unless Object.const_defined?(:Mysql2)
 
         @host = host
         @database_name = database_name

--- a/src/com/zoho/api/authenticator/store/db_store.rb
+++ b/src/com/zoho/api/authenticator/store/db_store.rb
@@ -1,4 +1,3 @@
-require 'mysql2'
 require_relative 'token_store'
 require_relative '../oauth_token'
 require_relative '../../../crm/api/util/constants'
@@ -17,6 +16,8 @@ module ZOHOCRMSDK
       # @param password A String containing the DataBase password.
       # @param port_number A String containing the DataBase port number.
       def initialize(host: Constants::MYSQL_HOST, database_name: Constants::MYSQL_DATABASE_NAME ,table_name: Constants::MYSQL_TABLE_NAME,user_name: Constants::MYSQL_USER_NAME,password: '',port_number: Constants::MYSQL_PORT_NUMBER )
+        require 'mysql2' unless const_defined?(:Mysql2)
+
         @host = host
         @database_name = database_name
         @table_name = table_name

--- a/src/com/zoho/api/logger/sdk_logger.rb
+++ b/src/com/zoho/api/logger/sdk_logger.rb
@@ -17,7 +17,7 @@ module ZOHOCRMSDK
         return Logger.new(File.open(File::NULL, 'w')) if self.level == Levels::OFF
 
         logger = self.path.nil? ? Logger.new(STDOUT) : Logger.new(self.path)
-        logger.level = Log.level ? const_get("LOGGER::#{Log.level}") : Logger::INFO
+        logger.level = Log.level ? Object.const_get("LOGGER::#{Log.level}") : Logger::INFO
         logger
       end
     end

--- a/src/com/zoho/api/logger/sdk_logger.rb
+++ b/src/com/zoho/api/logger/sdk_logger.rb
@@ -17,7 +17,7 @@ module ZOHOCRMSDK
         return Logger.new(File.open(File::NULL, 'w')) if self.level == Levels::OFF
 
         logger = self.path.nil? ? Logger.new(STDOUT) : Logger.new(self.path)
-        logger.level = Log.level ? Object.const_get("LOGGER::#{Log.level}") : Logger::INFO
+        logger.level = Log.level ? const_get("LOGGER::#{Log.level}") : Logger::INFO
         logger
       end
     end

--- a/src/com/zoho/api/logger/sdk_logger.rb
+++ b/src/com/zoho/api/logger/sdk_logger.rb
@@ -1,5 +1,3 @@
-require 'webrick/log'
-require 'webrick/accesslog'
 require 'logger'
 
 module ZOHOCRMSDK
@@ -14,66 +12,52 @@ module ZOHOCRMSDK
       def self.initialize(level:, path:nil)
         Log.new(level, path)
       end
-    
+
+      def as_logger
+        return Logger.new(File.open(File::NULL, 'w')) if self.level == Levels::OFF
+
+        logger = self.path.nil? ? Logger.new(STDOUT) : Logger.new(self.path)
+        logger.level = Log.level ? Object.const_get("LOGGER::#{Log.level}") : Logger::INFO
+        logger
+      end
     end
 
+    # Generic logger to support passing in a custom logger i.e. your application's Rails.logger
     class SDKLogger
-      @@path = nil
-      @@level = nil
-      @@log_levels_precedence = { 'FATAL' => 1,'SEVERE' => 1, 'ERROR' => 2, 'WARN' => 3, 'INFO' => 4, 'ALL' => 5,'DEBUG' => 5 ,'OFF' => 5}
-      @@logger = nil
-
       def self.initialize(log)
-
-        if !log.level.nil? && log.level != Levels::OFF && !log.path.nil? && log.path.length > 0 
-          if @@log_levels_precedence.key? log.level
-            File.new(log.path, 'w') unless File.exist? log.path if log.path != nil
-            sdk_logger = WEBrick::BasicLog.new(log.path, @@log_levels_precedence[log.level])
-          end
-        end
-
-        if !log.level.nil? && log.path.nil?
-          if  @@log_levels_precedence.key? log.level
-            sdk_logger = WEBrick::BasicLog.new(nil, @@log_levels_precedence[log.level])
-          end
-        end
-
-        @@logger = sdk_logger
+        return @logger = log.as_logger if log.is_a?(Log)
+        @logger = log
       rescue StandardError => e
         raise SDKException.new(nil, Constants::LOGGER_INITIALIZATION_ERROR, nil, e)
       end
 
       def self.info(message)
-        @@logger&.info(Time.new.to_s + ' ' + message)
+        @logger&.info("#{Time.new} #{message}")
       end
 
       def self.error(message, exception = nil)
-        unless exception.nil?
-          exception.to_s
-          message = message + exception.to_s + exception.backtrace.join("\n")
-        end
-        @@logger&.error(Time.new.to_s + ' ' + message)
+        message = "#{message}#{exception}#{exception.backtrace&.join("\n")}" unless exception.nil?
+        @logger&.error("#{Time.new} #{message}")
       end
 
       def self.warn(message)
-        @@logger&.warn(Time.new.to_s + ' ' + message)
+        @logger&.warn("#{Time.new} #{message}")
       end
 
       def self.severe(message, exception = nil)
-      
-        message = message + exception.to_s + exception.backtrace.join("\n") unless exception.nil?
-        @@logger&.fatal(Time.new.to_s + ' ' + message)
+        message = "#{message}#{exception}#{exception.backtrace&.join("\n")}" unless exception.nil?
+        @logger&.fatal("#{Time.new} #{message}")
       end
     end
   end
 
   module Levels
-    SEVERE = 'SEVERE'
+    SEVERE = 'FATAL'
     INFO = 'INFO'
-    WARNING = 'WARNING'
+    WARNING = 'WARN'
     ERROR = 'ERROR'
     DEBUG = 'DEBUG'
-    ALL = 'ALL'
+    ALL = 'DEBUG'
     OFF = 'OFF'
     FATAL = 'FATAL'
   end

--- a/src/com/zoho/api/logger/sdk_logger.rb
+++ b/src/com/zoho/api/logger/sdk_logger.rb
@@ -17,7 +17,7 @@ module ZOHOCRMSDK
         return Logger.new(File.open(File::NULL, 'w')) if self.level == Levels::OFF
 
         logger = self.path.nil? ? Logger.new(STDOUT) : Logger.new(self.path)
-        logger.level = self.level ? Object.const_get("LOGGER::#{self.level}") : Logger::INFO
+        logger.level = self.level ? Object.const_get("Logger::#{self.level}") : Logger::INFO
         logger
       end
     end

--- a/src/com/zoho/api/logger/sdk_logger.rb
+++ b/src/com/zoho/api/logger/sdk_logger.rb
@@ -17,7 +17,7 @@ module ZOHOCRMSDK
         return Logger.new(File.open(File::NULL, 'w')) if self.level == Levels::OFF
 
         logger = self.path.nil? ? Logger.new(STDOUT) : Logger.new(self.path)
-        logger.level = Log.level ? Object.const_get("LOGGER::#{Log.level}") : Logger::INFO
+        logger.level = self.level ? Object.const_get("LOGGER::#{self.level}") : Logger::INFO
         logger
       end
     end

--- a/src/com/zoho/crm/api/attachments/attachments_operations.rb
+++ b/src/com/zoho/crm/api/attachments/attachments_operations.rb
@@ -33,7 +33,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -56,7 +56,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -79,7 +79,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -102,7 +102,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -127,7 +127,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -151,7 +151,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s

--- a/src/com/zoho/crm/api/blue_print/blue_print_operations.rb
+++ b/src/com/zoho/crm/api/blue_print/blue_print_operations.rb
@@ -27,7 +27,7 @@ module ZOHOCRMSDK
       def get_blueprint
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -49,7 +49,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s

--- a/src/com/zoho/crm/api/initializer.rb
+++ b/src/com/zoho/crm/api/initializer.rb
@@ -25,7 +25,7 @@ require_relative 'util/constants'
 module ZOHOCRMSDK
   # This class to initialize Zoho CRM SDK.
   class Initializer
-    attr_accessor :json_details,:user, :environment, :store, :token, :initializer, :local, :sdk_config, :resources_path, :request_proxy
+    attr_accessor :json_details,:user, :environment, :store, :token, :initializer, :local, :sdk_config, :resources_path, :request_proxy, :api_version
     @@json_details = nil
 
     Thread.current['initi'] = nil
@@ -34,7 +34,7 @@ module ZOHOCRMSDK
       @@json_details
     end
 
-    def self.initialize(user:, environment:, token:, store: nil, sdk_config: nil, resources_path: nil, log: nil, request_proxy: nil)
+    def self.initialize(user:, environment:, token:, store: nil, sdk_config: nil, resources_path: nil, log: nil, request_proxy: nil, api_version: 2)
       error = {}
 
       require_relative 'user_signature'
@@ -115,7 +115,9 @@ module ZOHOCRMSDK
         raise SDKException.new(Constants::INITIALIZATION_ERROR, Constants::RESOURCE_PATH_INVALID_ERROR_MESSAGE, nil, nil)
       end
 
-      log = SDKLog::Log.initialize(level: Levels::INFO, path: File.join(Dir.pwd, Constants::LOG_FILE_NAME)) if log.nil? 
+      # Unless otherwise passed in, logging will be to filesystem using the WEBrick::BasicLog logger
+      log = SDKLog::Log.initialize(level: Levels::INFO, path: File.join(Dir.pwd, Constants::LOG_FILE_NAME)) if log.nil?
+
       SDKLog::SDKLogger.initialize(log)
 
       @@initializer = Initializer.new
@@ -133,6 +135,8 @@ module ZOHOCRMSDK
       @@initializer.resources_path = resources_path
 
       @@initializer.request_proxy = request_proxy
+
+      @@initializer.api_version = api_version
 
       @@json_details = get_JSONDetails
 
@@ -236,6 +240,8 @@ module ZOHOCRMSDK
       initializer.resources_path = @@initializer.resources_path
 
       initializer.request_proxy = request_proxy
+
+      initializer.api_version = @@initializer.api_version
 
       Thread.current['initi'] = initializer
 

--- a/src/com/zoho/crm/api/record/record_operations.rb
+++ b/src/com/zoho/crm/api/record/record_operations.rb
@@ -38,7 +38,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -75,7 +75,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -113,7 +113,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -145,7 +145,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         handler_instance.api_path = api_path
         handler_instance.http_method = Constants::REQUEST_METHOD_GET
@@ -176,7 +176,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         handler_instance.api_path = api_path
         handler_instance.http_method = Constants::REQUEST_METHOD_POST
@@ -208,7 +208,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         handler_instance.api_path = api_path
         handler_instance.http_method = Constants::REQUEST_METHOD_PUT
@@ -240,7 +240,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         handler_instance.api_path = api_path
         handler_instance.http_method = Constants::REQUEST_METHOD_DELETE
@@ -270,7 +270,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/upsert'
         handler_instance.api_path = api_path
@@ -303,7 +303,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/deleted'
         handler_instance.api_path = api_path
@@ -334,7 +334,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/search'
         handler_instance.api_path = api_path
@@ -390,7 +390,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -421,7 +421,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -452,7 +452,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + id.to_s
@@ -479,7 +479,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/actions/mass_update'
         handler_instance.api_path = api_path
@@ -508,7 +508,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/actions/mass_update'
         handler_instance.api_path = api_path
@@ -542,7 +542,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_field_value.to_s
@@ -579,7 +579,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_field_value.to_s
@@ -617,7 +617,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_field_value.to_s

--- a/src/com/zoho/crm/api/related_records/related_records_operations.rb
+++ b/src/com/zoho/crm/api/related_records/related_records_operations.rb
@@ -49,7 +49,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -80,7 +80,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -111,7 +111,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -145,7 +145,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s
@@ -176,7 +176,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s
@@ -207,7 +207,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s
@@ -241,7 +241,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -277,7 +277,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -310,7 +310,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -345,7 +345,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s
@@ -381,7 +381,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s
@@ -414,7 +414,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + external_value.to_s

--- a/src/com/zoho/crm/api/share_records/share_records_operations.rb
+++ b/src/com/zoho/crm/api/share_records/share_records_operations.rb
@@ -33,7 +33,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -56,7 +56,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -81,7 +81,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s
@@ -102,7 +102,7 @@ module ZOHOCRMSDK
       def revoke_shared_record
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + @module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + @record_id.to_s

--- a/src/com/zoho/crm/api/tags/tags_operations.rb
+++ b/src/com/zoho/crm/api/tags/tags_operations.rb
@@ -178,7 +178,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -210,7 +210,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/'
         api_path = api_path + record_id.to_s
@@ -238,7 +238,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/actions/add_tags'
         handler_instance.api_path = api_path
@@ -264,7 +264,7 @@ module ZOHOCRMSDK
         end
         handler_instance = Handler::CommonAPIHandler.new
         api_path = ''
-        api_path = api_path + '/crm/v2/'
+        api_path = api_path + "/crm/v#{Initializer.get_initializer.api_version}/"
         api_path = api_path + module_api_name.to_s
         api_path = api_path + '/actions/remove_tags'
         handler_instance.api_path = api_path

--- a/src/com/zoho/crm/api/util/converter.rb
+++ b/src/com/zoho/crm/api/util/converter.rb
@@ -227,7 +227,7 @@ module ZOHOCRMSDK
 
         bytes = file_name.force_encoding('utf-8').bytes
 
-        str = Base64.encode64(bytes.pack('"C*"'))
+        str = Base64.encode64(bytes.pack('C*'))
 
         str = str.chomp
 

--- a/src/version.rb
+++ b/src/version.rb
@@ -1,3 +1,3 @@
 module ZOHOCRMSDK
-  VERSION = '6.1.0'
+  VERSION = '6.2.0'
 end


### PR DESCRIPTION
# 6.2.0
## Bug Fixes:
* Fixed a bug in `src/api/util/converter.rb` causing noisy errors in log i.e. `<internal:pack>:8: warning: unknown pack directive '"' in '"C*"'`
* Removed the `mysql2` dependency from the gemspec as the mysql token store is optional
* Removed the unspecified `webrick` gem dependency which was only used for logging. Switched the `SDKLog::Log` class to use
  a standard Ruby `Logger` instead under the hood as the default logger. The default logging behavior and interface is unchanged.

## Enhancements:
* Custom Logger Support - Pass in a custom logger to `ZOHOCRMSDK::Initializer.initialize` - this now supports passing in `Rails.logger`, for instance
* Added `api_version` option to `ZOHOCRMSDK::Initializer.initialize` which defaults to `2`. This sets the crm API base path for operations from `/crm/v2/` to `/crm/v{version}/`